### PR TITLE
Add Dockerfile and CLI input option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir pycryptodome
+ENTRYPOINT ["python", "decrypt-wg.py"]
+CMD []

--- a/decrypt-wg.py
+++ b/decrypt-wg.py
@@ -64,7 +64,7 @@ def aes_wrap_key_withpad(kek, plaintext):
         return AES.new(kek, AES.MODE_ECB).encrypt(QUAD.pack(iv) + plaintext)
     return aes_wrap_key(kek, plaintext, iv)
 
-def test():
+def test(psk_input=None):
     #test vector from RFC 3394
     import binascii
     import sys
@@ -73,8 +73,10 @@ def test():
     array_kek = [ 29, 3, 245, 130, 135, 152, 43, 199, 1, 34, 115, 148, 228, 152, 222, 35 ]
     #print ''.join('{:02x}'.format(x) for x in array_kek)
     #print binascii.hexlify(KEK)
-    print("Input PSK: ")
-    user_input = sys.stdin.readline().translate({ord('+'): None})
+    if psk_input is None:
+        print("Input PSK: ")
+        psk_input = sys.stdin.readline()
+    user_input = psk_input.translate({ord('+'): None})
     CIPHER = binascii.unhexlify(user_input.strip())
     #CIPHER = binascii.unhexlify("9539C9564FB73887D8CCA21F7B29FD3FE60E471D80C9B371")
     #CIPHER = binascii.unhexlify("0E611DC31F2AEBB4A6E69F2641E1E83D762F514F3636E1EFA86B9BDECFEFADFB")
@@ -85,4 +87,6 @@ def test():
     #assert aes_wrap_key(KEK, PLAIN) == CIPHER
 
 if __name__ == '__main__':
-    test()
+    import sys
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    test(arg)

--- a/readme.md
+++ b/readme.md
@@ -10,3 +10,18 @@ PSKs starting with '+' character are able to be decrypted.
 NEEDED:
 - Python 3
 - pip install pycryptodome
+
+## Docker
+
+Build the Docker image and run the tool:
+
+```bash
+docker build -t decrypt-wg .
+echo "+HEXPSK" | docker run -i decrypt-wg
+```
+
+You can also pass the PSK as the first command line argument:
+
+```bash
+docker run decrypt-wg +HEXPSK
+```


### PR DESCRIPTION
## Summary
- allow decrypt-wg.py to read input from stdin or as first argument
- document Docker usage
- add Dockerfile for containerized execution

## Testing
- `pip install pycryptodome`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880739e73c88325affd5b83b747908f